### PR TITLE
Using multi-stage builds to reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
-FROM golang:1.12
-RUN go get github.com/toggler-io/toggler/cmd/toggler
-ENTRYPOINT ["toggler"]
-CMD ["http-server", "-port", "8080"]
+FROM golang:1.14-alpine as build
 EXPOSE 8080
+
+WORKDIR /src/
+COPY . .
+RUN CGO_ENABLED=0 go build -o /bin/toggler cmd/toggler/main.go
+
+FROM scratch
+COPY --from=build /bin/toggler /bin/toggler
+
+ENTRYPOINT ["/bin/toggler"]
+CMD ["http-server", "-port", "8080"]

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/adamluzsi/frameless v0.4.0
 	github.com/adamluzsi/gorest v0.6.1
 	github.com/adamluzsi/testcase v0.5.2
-	github.com/go-openapi/errors v0.19.4
+	github.com/go-openapi/errors v0.19.4 // indirect
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
-	github.com/go-openapi/swag v0.19.9
-	github.com/go-openapi/validate v0.19.8
+	github.com/go-openapi/swag v0.19.9 // indirect
+	github.com/go-openapi/validate v0.19.8 // indirect
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/go-swagger/go-swagger v0.23.0
 	github.com/golang-migrate/migrate/v4 v4.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/toggler-io/toggler
 
-go 1.12
+go 1.14
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0


### PR DESCRIPTION
Hi Adam,
I was looking into your project which looks very promising to me on a technical level but also to learn about a lot of coding principles.

Trying to build the Container Image locally I was running into a couple of problems. 

- The go.mod file referenced Go 1.12 which doesn't support the new error handling `error.As` for example and one of your dependencies is using it.
- The manifest of the container image couldn't be build due to missing of the `GO111MODULE` needed to be set to "On" or "Auto" (AFAIK :) ).

So I thought improving it to reduce the size from **881MB** to **18.2MB**.

I used multi-stage builds and instead of using `go get`, I thought it would be easier to just copy the code already there on the local machine (so we don't to grab it again).

Thoughts and ideas are more then welcomed,
Take care!