### PR TITLE
remove obsolete version from docker compose yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3'
-
 services:
   pg:
     image: "postgres"


### PR DESCRIPTION
docker compose was giving a warning about how the attribute `version` is obsolete and will be ignored